### PR TITLE
sys: use runtime/default for seccomp

### DIFF
--- a/cluster-wide/coredns-psp.yaml
+++ b/cluster-wide/coredns-psp.yaml
@@ -27,7 +27,7 @@ kind: PodSecurityPolicy
 metadata:
   name: coredns
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 spec:
   seLinux:
     rule: RunAsAny

--- a/namespaced/coredns.yaml
+++ b/namespaced/coredns.yaml
@@ -43,7 +43,7 @@ spec:
       labels:
         k8s-app: kube-dns
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
docker/default is deprecated:
https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp